### PR TITLE
Add webpack-monitor to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "eslint-plugin-react": "^7.4.0",
     "npm-run-all": "^4.1.1",
     "webpack": "^3.6.0",
-    "webpack-dev-server": "^2.8.2"
+    "webpack-dev-server": "^2.8.2",
+    "webpack-monitor": "^1.0.13"
   },
   "dependencies": {
     "d3": "^4.10.2",


### PR DESCRIPTION
This was missing when I did `npm start`.