### PR TITLE
Fix some major compilation bugs

### DIFF
--- a/chrome-ext/devtools.html
+++ b/chrome-ext/devtools.html
@@ -2,7 +2,6 @@
   Created by Grant Kang, William He, and David Sally on 9/10/17.
   Copyright © 2018 React Sight. All rights reserved.
  -->
-<html>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -112,7 +111,7 @@
     </div>
   </div>
 
-  <script src="./build/bundle.js"></script>
+  <script src="bundle.js"></script>
 </body>
 
 </html>

--- a/chrome-ext/frontend/devtools.js
+++ b/chrome-ext/frontend/devtools.js
@@ -7,7 +7,6 @@ import drawLoadingScreen from './loader';
 import * as drawChart from './drawChart';
 import drawBreadcrumbs from './breadcrumb';
 import { filterRedux, filterRouter, filterDOM } from './filters';
-import { mockDOM } from '../../test/fixtures';
 
 import '../css/style.css';
 import '../css/bootstrap.min.css';
@@ -70,7 +69,7 @@ const addListeners = () => {
  * Add panel to chrome dev tools and initialize port and listener
  */
 const drawPanel = () => {
-  chrome.devtools.panels.create('React-Sight', null, 'devtools.html', () => {
+  chrome.devtools.panels.create('React-Sight', '', 'devtools.html', () => {
     addListeners();
     const port = chrome.extension.connect({ name: 'React-Sight' });
 
@@ -92,17 +91,5 @@ const drawPanel = () => {
   });
 };
 
-// ****************`
-// ***** MAIN *****
-// ****************
 // attach panel to chrome dev tools
-if (process.env.NODE_ENV === 'development') {
-  addListeners();
-  drawLoadingScreen();
-  curData = mockDOM;
-  setTimeout(() => {
-    draw();
-  }, 1000);
-} else {
-  drawPanel();
-}
+drawPanel();

--- a/chrome-ext/frontend/drawChart.js
+++ b/chrome-ext/frontend/drawChart.js
@@ -2,7 +2,7 @@
 //  Copyright © 2018 React Sight. All rights reserved.
 
 import * as d3 from 'd3';
-import { parseSvg } from "d3-interpolate/src/transform/parse";
+import { parseSvg } from 'd3-interpolate/src/transform/parse';
 import updateStateProps from './state-props-panel';
 
 // ************

--- a/chrome-ext/manifest.json
+++ b/chrome-ext/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "React-Sight",
   "version": "1.0.6",
   "description": "Extends the Developer Tools, adding a sidebar that displays React Component Hierarchy.",
-  "devtools_page": "build/devtools.html",
+  "devtools_page": "devtools.html",
   "manifest_version": 2,
   "background": {
     "scripts": [

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/React-Sight/React-Sight#readme",
   "dependencies": {
     "d3": "5.9.7",
+    "d3-interpolate": "1.3.2",
     "json-formatter-js": "2.2.1",
     "lodash": "4.17.14"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,23 +18,9 @@ module.exports = {
 
   output: {
     filename: '[name].js',
-    path: `${__dirname}/release/build`,
+    path: `${__dirname}/build/chrome-ext`,
   },
 
-  optimization: {
-    splitChunks: {
-      cacheGroups: {
-        default: false,
-        commons: {
-          test: /[\\/]node_modules[\\/]/,
-          name: 'vendor',
-          chunks: 'all',
-        },
-      },
-    },
-  },
-
-  // use a load for .jsx and ES6
   module: {
     rules: [
       {
@@ -59,11 +45,11 @@ module.exports = {
   plugins: [
     new CopyWebpackPlugin([
       // {output}/to/file.txt
-      { from: 'chrome-ext/manifest.json', to: '../manifest.json' },
-      { from: 'chrome-ext/content-script.js', to: '../content-script.js' },
-      { from: 'chrome-ext/background.js', to: '../background.js' },
-      { from: 'chrome-ext/devtools.html', to: '../devtools.html' },
-      { from: 'chrome-ext/asset/', to: '../asset/' },
+      { from: 'chrome-ext/manifest.json', to: '../chrome-ext/manifest.json' },
+      { from: 'chrome-ext/content-script.js', to: '../chrome-ext/content-script.js' },
+      { from: 'chrome-ext/background.js', to: '../chrome-ext/background.js' },
+      { from: 'chrome-ext/devtools.html', to: '../chrome-ext/devtools.html' },
+      { from: 'chrome-ext/asset/', to: '../chrome-ext/asset/' },
     ]),
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2618,7 +2618,7 @@ d3-hierarchy@1:
   resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz#7a6317bd3ed24e324641b6f1e76e978836b008cc"
   integrity sha512-L+GHMSZNwTpiq4rt9GEsNcpLa4M96lXMR8M/nMG9p5hBE0jy6C+3hWtyZMenPQdwla249iJy7Nx0uKt3n+u9+w==
 
-d3-interpolate@1:
+d3-interpolate@1, d3-interpolate@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.3.2.tgz#417d3ebdeb4bc4efcc8fd4361c55e4040211fd68"
   integrity sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==


### PR DESCRIPTION
React-Sight was completely broken this should fix it. This does some
things:
  - remove extra <html> tag from devtools.html
  - remove weird 'development' mode logic from devtools.js
  - add missing d3-interpolate function
  - fix build folder issues