### PR TITLE
Bump lodash version and update throttle import

### DIFF
--- a/chrome-ext/frontend/devtools.js
+++ b/chrome-ext/frontend/devtools.js
@@ -1,7 +1,7 @@
 //  Created by Grant Kang, William He, and David Sally on 9/10/17.
 //  Copyright © 2018 React Sight. All rights reserved.
 
-import { throttle } from 'lodash';
+import throttle from 'lodash/throttle';
 import drawStore from './store-panel';
 import drawLoadingScreen from './loader';
 import * as drawChart from './drawChart';

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "d3": "5.15.0",
     "d3-interpolate": "1.4.0",
     "json-formatter-js": "2.2.1",
-    "lodash": "4.17.14"
+    "lodash": "4.17.15"
   },
   "devDependencies": {
     "@babel/core": "7.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6237,15 +6237,15 @@ lodash.tail@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
   integrity sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=
 
-lodash@4.17.14, lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@~4.17.10:
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
-  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
-
-lodash@^4.17.13, lodash@^4.17.15:
+lodash@4.17.15, lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@~4.17.10:
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
+  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
 log-driver@^1.2.5:
   version "1.2.7"


### PR DESCRIPTION
I was going to add the individual throttle package, but the docs say this will be deprecated in v5