### PR TITLE
Update extension to be compatible with firefox

### DIFF
--- a/chrome-ext/content-script.js
+++ b/chrome-ext/content-script.js
@@ -21,7 +21,7 @@ window.addEventListener('message', (e) => {
   });
 });
 
-chrome.extension.onMessage.addListener(() => {
+chrome.runtime.onMessage.addListener(() => {
   const newEvent = new Event('reactsight');
   window.dispatchEvent(newEvent);
 });

--- a/chrome-ext/frontend/devtools.js
+++ b/chrome-ext/frontend/devtools.js
@@ -71,7 +71,7 @@ const addListeners = () => {
  * Add panel to chrome dev tools and initialize port and listener
  */
 const drawPanel = () => {
-  chrome.devtools.panels.create('React-Sight', null, 'devtools.html', () => {
+  chrome.devtools.panels.create('React-Sight', '', 'devtools.html', () => {
     addListeners();
     const port = chrome.runtime.connect({ name: 'React-Sight' });
 

--- a/chrome-ext/manifest.json
+++ b/chrome-ext/manifest.json
@@ -8,14 +8,13 @@
   "background": {
     "scripts": [
       "background.js"
-    ],
-    "persistent": false
+    ]
   },
   "content_scripts": [{
     "matches": ["<all_urls>"],
     "js": ["content-script.js"]
   }],
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "content_security_policy": "script-src 'self'; object-src 'self'",
   "icons": {
     "16": "asset/icon16.png",
     "48": "asset/icon48.png",


### PR DESCRIPTION
Firefox has implemented nearly the same API as chrome, so porting this
extension is relatively easy. Changes:
  - use `runtime` api over `extension` api (deprecated)
  - remove background: persistent and unsafe_eval from manifest
    (they are not unused anyways)
  - update icons param in devtools.panels.create call from null to ''.
    Firefox only allows strings, and throws an error if null is passed.