### PR TITLE
Fix circular dependency and null store errors

### DIFF
--- a/extension/backend/installHook.js
+++ b/extension/backend/installHook.js
@@ -6,6 +6,7 @@
 import { traverse16 } from './fiber-hook';
 import { getData } from './react-15-hook';
 
+// TODO fix this, I don't think node.process.env exits here, maybe need the define plugin
 var __ReactSightDebugMode = (process.env.NODE_ENV === 'debug');
 
 // Notes... might need additional testing..renderers provides a list of all imported React instances
@@ -45,6 +46,8 @@ if (!__ReactSightHasRun) {
     if (instance && instance.version) {
       __ReactSight_ReactVersion = instance.version;
       if (__ReactSightDebugMode) console.log('version: ', __ReactSight_ReactVersion);
+
+      // onCommitFiberRoot
       devTools.onCommitFiberRoot = (function (original) {
         return function (...args) {
           __ReactSightFiberDOM = args[1];

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "lint": "eslint extension",
     "start": "webpack -w",
+    "start:debug": "NODE_ENV=debug webpack -w",
     "test": "jest",
     "coveralls": "NODE_PATH=. node_modules/.bin/jest && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "build": "webpack -p",
@@ -29,6 +30,7 @@
   },
   "homepage": "https://github.com/React-Sight/React-Sight#readme",
   "dependencies": {
+    "circular": "^1.0.5",
     "d3": "5.15.0",
     "d3-interpolate": "1.4.0",
     "json-formatter-js": "2.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2125,6 +2125,11 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+circular@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/circular/-/circular-1.0.5.tgz#7da77af98bbde9ce4b5b358cd556b5dded2d3149"
+  integrity sha1-fad6+Yu96c5LWzWM1Va13e0tMUk=
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"


### PR DESCRIPTION
This fixes two major bugs:

1. Cannot read undefined from the `store` - when store was null /
undefined, the parser would crash. This initializes it to a safe value,
and wraps the parser in a try / catch.

2. Circular references in the DOM data would crash the JSON.parse call,
this fixes that by removing circular references using the `circular`
package.

Shout out to everyone who has commented "this doesn't work" since 2017!
I gotchu fam!